### PR TITLE
Add support for loading assemblies through MetadataReference

### DIFF
--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -1,4 +1,11 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RazorEngineCore.Tests.Models;
 
@@ -452,6 +459,62 @@ void RecursionTest(int level)
                 });
             });
 
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public async Task TestCompileAndRun_MetadataReference()
+        {
+            string greetingClass = @"
+namespace TestAssembly
+{
+    public static class Greeting
+    {
+        public static string GetGreeting(string name)
+        {
+            return ""Hello, "" + name + ""!"";
+        }
+    }
+}
+";
+            
+            RazorEngine razorEngine = new RazorEngine();
+            IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync(@"
+@using TestAssembly
+<p>@Greeting.GetGreeting(""Name"")</p>
+", builder =>
+            {
+                // This needs to be done in the builder to have access to all of the assemblies added through
+                // the various AddAssemblyReference options
+                CSharpCompilation compilation = CSharpCompilation.Create(
+                    "TestAssembly",
+                    new []
+                    {
+                        CSharpSyntaxTree.ParseText(greetingClass)
+                    },
+                    builder.Options.ReferencedAssemblies
+                        .Select(ass => MetadataReference.CreateFromFile(ass.Location)).ToList(),
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                );
+                MemoryStream memoryStream = new MemoryStream();
+                EmitResult emitResult = compilation.Emit(memoryStream);
+                if (!emitResult.Success) return;
+                
+                memoryStream.Position = 0;
+                builder.AddMetadataReference(MetadataReference.CreateFromStream(memoryStream));
+                    
+                // Add an assembly resolver so the assembly can be found
+                AppDomain.CurrentDomain.AssemblyResolve += (sender, eventArgs) =>
+                    new AssemblyName(eventArgs.Name ?? string.Empty).Name == "TestAssembly"
+                        ? Assembly.Load(memoryStream.ToArray())
+                        : null;
+            });
+
+            string expected = @"
+<p>Hello, Name!</p>
+";
+            string actual = await template.RunAsync();
+            
             Assert.AreEqual(expected, actual);
         }
     }

--- a/RazorEngineCore/IRazorEngineCompilationOptionsBuilder.cs
+++ b/RazorEngineCore/IRazorEngineCompilationOptionsBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace RazorEngineCore
 {
@@ -12,6 +13,8 @@ namespace RazorEngineCore
         void AddAssemblyReference(Assembly assembly);
         
         void AddAssemblyReference(Type type);
+
+        void AddMetadataReference(MetadataReference reference);
         
         void AddUsing(string namespaceName);
         

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -83,7 +83,7 @@ namespace RazorEngineCore
                 },
                 options.ReferencedAssemblies
                     .Select(ass => MetadataReference.CreateFromFile(ass.Location))
-                    .ToList(),
+                    .Concat(options.MetadataReferences).ToList(),
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             MemoryStream memoryStream = new MemoryStream();

--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace RazorEngineCore
 {
@@ -16,6 +17,8 @@ namespace RazorEngineCore
             Assembly.Load(new AssemblyName("System.Linq.Expressions"))
         };
 
+        public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
+        
         public string TemplateNamespace { get; set; } = "TemplateNamespace";
         public string Inherits { get; set; } = "RazorEngineCore.RazorEngineTemplateBase";
 

--- a/RazorEngineCore/RazorEngineCompilationOptionsBuilder.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptionsBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace RazorEngineCore
 {
@@ -32,6 +33,11 @@ namespace RazorEngineCore
             {
                 this.AddAssemblyReference(argumentType);
             }
+        }
+
+        public void AddMetadataReference(MetadataReference reference)
+        {
+            this.Options.MetadataReferences.Add(reference);
         }
 
         public void AddUsing(string namespaceName)


### PR DESCRIPTION
This adds support for loading assemblies through a `MetadataReference` object instead of an `Assembly` object. This allows you to compile an assembly in memory and reference it in a template (an example of this can be seen in the `TestCompileAndRun_MetadataReference` method).