### PR TITLE
Removed explicit loading of assembly netstandard

### DIFF
--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -11,14 +11,13 @@ namespace RazorEngineCore
             typeof(object).Assembly,
             Assembly.Load(new AssemblyName("Microsoft.CSharp")),
             typeof(RazorEngineTemplateBase).Assembly,
-            Assembly.Load(new AssemblyName("netstandard")),
             Assembly.Load(new AssemblyName("System.Runtime")),
             Assembly.Load(new AssemblyName("System.Linq")),
             Assembly.Load(new AssemblyName("System.Linq.Expressions"))
         };
 
         public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
-        
+
         public string TemplateNamespace { get; set; } = "TemplateNamespace";
         public string Inherits { get; set; } = "RazorEngineCore.RazorEngineTemplateBase";
 


### PR DESCRIPTION
Causes error when running on Linux/Docker and has no negative implications on Windows.

netstandard.dll is not meant to be loaded as it is just a shim.