### PR TITLE
Removed explicit loading of netstandard on Linux/OSX only

### DIFF
--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -1,20 +1,38 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 
 namespace RazorEngineCore
 {
     public class RazorEngineCompilationOptions
     {
-        public HashSet<Assembly> ReferencedAssemblies { get; set; } = new HashSet<Assembly>()
-        {
-            typeof(object).Assembly,
-            Assembly.Load(new AssemblyName("Microsoft.CSharp")),
-            typeof(RazorEngineTemplateBase).Assembly,
-            Assembly.Load(new AssemblyName("System.Runtime")),
-            Assembly.Load(new AssemblyName("System.Linq")),
-            Assembly.Load(new AssemblyName("System.Linq.Expressions"))
-        };
+        private HashSet<Assembly> _referencedAssemblies;
+        public HashSet<Assembly> ReferencedAssemblies {
+            get
+            {
+                if (this._referencedAssemblies != null)
+                    return this._referencedAssemblies;
+
+                this._referencedAssemblies = new HashSet<Assembly>()
+                {
+                    typeof(object).Assembly,
+                    Assembly.Load(new AssemblyName("Microsoft.CSharp")),
+                    typeof(RazorEngineTemplateBase).Assembly,
+                    Assembly.Load(new AssemblyName("System.Runtime")),
+                    Assembly.Load(new AssemblyName("System.Linq")),
+                    Assembly.Load(new AssemblyName("System.Linq.Expressions"))
+                };
+
+                // Loading netstandard explicitly causes runtime error on Linux/OSX
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    this._referencedAssemblies.Add(Assembly.Load(new AssemblyName("netstandard")));
+                }
+
+                return this._referencedAssemblies;
+            }
+        } 
 
         public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
 

--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -11,14 +11,13 @@ namespace RazorEngineCore
             typeof(object).Assembly,
             Assembly.Load(new AssemblyName("Microsoft.CSharp")),
             typeof(RazorEngineTemplateBase).Assembly,
-            Assembly.Load(new AssemblyName("netstandard")),
             Assembly.Load(new AssemblyName("System.Runtime")),
             Assembly.Load(new AssemblyName("System.Linq")),
             Assembly.Load(new AssemblyName("System.Linq.Expressions"))
         };
 
         public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
-        
+
         public string TemplateNamespace { get; set; } = "TemplateNamespace";
         public string Inherits { get; set; } = "RazorEngineCore.RazorEngineTemplateBase";
 


### PR DESCRIPTION
Caused runtime failure on Linux (and most propably OSX)

```
System.IO.FileNotFoundException: Could not load file or assembly 'netstandard, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.

File name: 'netstandard, Culture=neutral, PublicKeyToken=null'
   at System.Reflection.RuntimeAssembly.nLoad(AssemblyName fileName, String codeBase, RuntimeAssembly assemblyContext, StackCrawlMark& stackMark, Boolean throwOnFileNotFound, AssemblyLoadContext assemblyLoadContext)
   at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext)
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext)
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef)
   at RazorEngineCore.RazorEngineCompilationOptions..ctor()
   at RazorEngineCore.RazorEngineCompilationOptionsBuilder..ctor(RazorEngineCompilationOptions options)
   at RazorEngineCore.RazorEngine.Compile(String content, Action`1 builderAction)
   at RazorEngineCore.RazorEngine.<>c__DisplayClass3_0.<CompileAsync>b__0()
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location where exception was thrown ---
```