### PR TITLE
Add support for compiling and running sets of templates

### DIFF
--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace RazorEngineCore
@@ -14,5 +15,19 @@ namespace RazorEngineCore
         IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
         
         Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
+
+        IRazorEngineCompiledTemplateSet<T> CompileSet<T>(Dictionary<string, string> contents,
+            Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, List<string> csharpFiles = null)
+            where T : IRazorEngineTemplate;
+
+        Task<IRazorEngineCompiledTemplateSet<T>> CompileSetAsync<T>(Dictionary<string, string> contents,
+            Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, List<string> csharpFiles = null)
+            where T : IRazorEngineTemplate;
+        
+        IRazorEngineCompiledTemplateSet CompileSet(Dictionary<string, string> contents,
+            Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, List<string> csharpFiles = null);
+
+        Task<IRazorEngineCompiledTemplateSet> CompileSetAsync(Dictionary<string, string> contents,
+            Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, List<string> csharpFiles = null);
     }
 }

--- a/RazorEngineCore/IRazorEngineCompilationOptionsBuilder.cs
+++ b/RazorEngineCore/IRazorEngineCompilationOptionsBuilder.cs
@@ -15,7 +15,7 @@ namespace RazorEngineCore
         void AddAssemblyReference(Type type);
 
         void AddMetadataReference(MetadataReference reference);
-        
+
         void AddUsing(string namespaceName);
         
         void Inherits(Type type);

--- a/RazorEngineCore/IRazorEngineCompiledTemplateSet.cs
+++ b/RazorEngineCore/IRazorEngineCompiledTemplateSet.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace RazorEngineCore
+{
+    public interface IRazorEngineCompiledTemplateSet
+    {
+        void SaveToStream(Stream stream);
+        
+        Task SaveToStreamAsync(Stream stream);
+        
+        void SaveToFile(string fileName);
+        
+        Task SaveToFileAsync(string fileName);
+        
+        string Run(string templateClassName, object model = null);
+        
+        Task<string> RunAsync(string templateClassName, object model = null);
+    }
+}

--- a/RazorEngineCore/IRazorEngineCompiledTemplateSetT.cs
+++ b/RazorEngineCore/IRazorEngineCompiledTemplateSetT.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace RazorEngineCore
+{
+    public interface IRazorEngineCompiledTemplateSet<out T>
+        where T : IRazorEngineTemplate
+    {
+        void SaveToStream(Stream stream);
+        
+        Task SaveToStreamAsync(Stream stream);
+        
+        void SaveToFile(string fileName);
+        
+        Task SaveToFileAsync(string fileName);
+        
+        string Run(string templateClassName, Action<T> initializer);
+        
+        Task<string> RunAsync(string templateClassName, Action<T> initializer);
+    }
+}

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -115,7 +115,7 @@ namespace RazorEngineCore
                 RazorEngineCompilationException exception = new RazorEngineCompilationException($"Unable to compile template: {errors.FirstOrDefault()}")
                 {
                     Errors = errors,
-                    GeneratedCode = razorCSharpDocument.GeneratedCode
+                    GeneratedCode = generatedCode
                 };
 
                 throw exception;

--- a/RazorEngineCore/RazorEngineCompiledTemplateSet.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplateSet.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace RazorEngineCore
+{
+    public class RazorEngineCompiledTemplateSet : IRazorEngineCompiledTemplateSet
+    {
+        private readonly MemoryStream assemblyByteCode;
+        private readonly Assembly assembly;
+        private readonly string templateNamespace;
+
+        internal RazorEngineCompiledTemplateSet(MemoryStream assemblyByteCode, string templateNamespace = "TemplateNamespace")
+        {
+            this.assemblyByteCode = assemblyByteCode;
+            this.templateNamespace = templateNamespace;
+
+            assembly = Assembly.Load(assemblyByteCode.ToArray());
+        }
+
+        public static IRazorEngineCompiledTemplateSet LoadFromFile(string fileName, string templateNamespace = "TemplateNamespace")
+        {
+            return LoadFromFileAsync(fileName: fileName, templateNamespace).GetAwaiter().GetResult();
+        }
+
+        public static async Task<IRazorEngineCompiledTemplateSet> LoadFromFileAsync(string fileName, string templateNamespace = "TemplateNamespace")
+        {
+            MemoryStream memoryStream = new MemoryStream();
+            
+            using (FileStream fileStream = new FileStream(
+                path: fileName, 
+                mode: FileMode.Open, 
+                access: FileAccess.Read,
+                share: FileShare.None,
+                bufferSize: 4096, 
+                useAsync: true))
+            {
+                await fileStream.CopyToAsync(memoryStream);
+            }
+            
+            return new RazorEngineCompiledTemplateSet(memoryStream, templateNamespace);
+        }
+        
+        public static IRazorEngineCompiledTemplateSet LoadFromStream(Stream stream, string templateNamespace = "TemplateNamespace")
+        {
+            return LoadFromStreamAsync(stream, templateNamespace).GetAwaiter().GetResult();
+        }
+        
+        public static async Task<IRazorEngineCompiledTemplateSet> LoadFromStreamAsync(Stream stream, string templateNamespace = "TemplateNamespace")
+        {
+            MemoryStream memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+            memoryStream.Position = 0;
+            
+            return new RazorEngineCompiledTemplateSet(memoryStream, templateNamespace);
+        }
+
+        public void SaveToStream(Stream stream)
+        {
+            this.SaveToStreamAsync(stream).GetAwaiter().GetResult();
+        }
+
+        public Task SaveToStreamAsync(Stream stream)
+        {
+            return this.assemblyByteCode.CopyToAsync(stream);
+        }
+
+        public void SaveToFile(string fileName)
+        {
+            this.SaveToFileAsync(fileName).GetAwaiter().GetResult();
+        }
+        
+        public Task SaveToFileAsync(string fileName)
+        {
+            using (FileStream fileStream = new FileStream(
+                path: fileName, 
+                mode: FileMode.OpenOrCreate, 
+                access: FileAccess.Write,
+                share: FileShare.None,
+                bufferSize: 4096, 
+                useAsync: true))
+            {
+                return assemblyByteCode.CopyToAsync(fileStream);
+            }
+        }
+        
+        public string Run(string templateClassName, object model = null)
+        {
+            return this.RunAsync(templateClassName, model).GetAwaiter().GetResult();
+        }
+        
+        public async Task<string> RunAsync(string templateClassName, object model = null)
+        {
+            if (model != null && model.IsAnonymous())
+            {
+                model = new AnonymousTypeWrapper(model);
+            }
+
+            var foo = assembly.GetType(templateNamespace + "." + templateClassName);
+            
+            IRazorEngineTemplate instance =
+                (IRazorEngineTemplate) Activator.CreateInstance(
+                    assembly.GetType(templateNamespace + "." + templateClassName));
+            instance.Model = model;
+
+            await instance.ExecuteAsync();
+
+            return instance.Result();
+        }
+    }
+}

--- a/RazorEngineCore/RazorEngineCompiledTemplateSetT.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplateSetT.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace RazorEngineCore
+{
+    public class RazorEngineCompiledTemplateSet<T> : IRazorEngineCompiledTemplateSet<T> where T : IRazorEngineTemplate
+    {
+        private readonly MemoryStream assemblyByteCode;
+        private readonly Assembly assembly;
+        private readonly string templateNamespace;
+
+        internal RazorEngineCompiledTemplateSet(MemoryStream assemblyByteCode, string templateNamespace = "TemplateNamespace")
+        {
+            this.assemblyByteCode = assemblyByteCode;
+            this.templateNamespace = templateNamespace;
+            
+            assembly = Assembly.Load(assemblyByteCode.ToArray());
+        }
+
+        public static IRazorEngineCompiledTemplateSet<T> LoadFromFile(string fileName, string templateNamespace = "TemplateNamespace")
+        {
+            return LoadFromFileAsync(fileName: fileName, templateNamespace).GetAwaiter().GetResult();
+        }
+
+        public static async Task<IRazorEngineCompiledTemplateSet<T>> LoadFromFileAsync(string fileName, string templateNamespace = "TemplateNamespace")
+        {
+            MemoryStream memoryStream = new MemoryStream();
+            
+            using (FileStream fileStream = new FileStream(
+                path: fileName, 
+                mode: FileMode.Open, 
+                access: FileAccess.Read,
+                share: FileShare.None,
+                bufferSize: 4096, 
+                useAsync: true))
+            {
+                await fileStream.CopyToAsync(memoryStream);
+            }
+            
+            return new RazorEngineCompiledTemplateSet<T>(memoryStream, templateNamespace);
+        }
+        
+        public static IRazorEngineCompiledTemplateSet<T> LoadFromStream(Stream stream, string templateNamespace = "TemplateNamespace")
+        {
+            return LoadFromStreamAsync(stream, templateNamespace).GetAwaiter().GetResult();
+        }
+        
+        public static async Task<IRazorEngineCompiledTemplateSet<T>> LoadFromStreamAsync(Stream stream, string templateNamespace = "TemplateNamespace")
+        {
+            MemoryStream memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+            memoryStream.Position = 0;
+            
+            return new RazorEngineCompiledTemplateSet<T>(memoryStream, templateNamespace);
+        }
+
+        public void SaveToStream(Stream stream)
+        {
+            this.SaveToStreamAsync(stream).GetAwaiter().GetResult();
+        }
+
+        public Task SaveToStreamAsync(Stream stream)
+        {
+            return this.assemblyByteCode.CopyToAsync(stream);
+        }
+
+        public void SaveToFile(string fileName)
+        {
+            this.SaveToFileAsync(fileName).GetAwaiter().GetResult();
+        }
+        
+        public Task SaveToFileAsync(string fileName)
+        {
+            using (FileStream fileStream = new FileStream(
+                path: fileName, 
+                mode: FileMode.OpenOrCreate, 
+                access: FileAccess.Write,
+                share: FileShare.None,
+                bufferSize: 4096, 
+                useAsync: true))
+            {
+                return assemblyByteCode.CopyToAsync(fileStream);
+            }
+        }
+        
+        public string Run(string templateClassName, Action<T> initializer)
+        {
+            return this.RunAsync(templateClassName, initializer).GetAwaiter().GetResult();
+        }
+        
+        public async Task<string> RunAsync(string templateClassName, Action<T> initializer)
+        {
+            T instance = (T) Activator.CreateInstance(assembly.GetType(templateNamespace + "." + templateClassName));
+            initializer(instance);
+            
+            await instance.ExecuteAsync();
+
+            return instance.Result();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for compiling and running sets of templates. An example of how this works can be seen in the test `TestCompileAndRun_Set`:
```csharp
        public void TestCompileAndRun_Set()
        {
            RazorEngine razorEngine = new RazorEngine();
            IRazorEngineCompiledTemplateSet templateSet = razorEngine.CompileSet(new Dictionary<string, string>
            {
                { "Template1", "@Template2.GetGreeting(Model.Name)\n@Greeting.GetGreeting(Model.Name)" },
                { "Template2", @"
Hello!
@functions {
    public static string GetGreeting(string name)
    {
        return ""Hello, "" + name + ""!"";
    }
}
" }
            }, builder => { builder.Options.TemplateNamespace = "Testing"; }, new List<string>
            {
                @"
namespace Testing
{
    public static class Greeting
    {
        public static string GetGreeting(string name)
        {
            return ""Hello, "" + name + ""!"";
        }
    }
}
"
            });
            string actual = templateSet.Run("Template1", new {Name = "Alex"});
            Assert.AreEqual("Hello, Alex!\nHello, Alex!", actual);
        }
```

Both `Template1` and `Template2` are compiled into the same assembly/`IRazorEngineCompiledTemplateSet`, and the template to run can be selected by its class name (set in the dictionary of template sources). In addition, you can provide a list of strings to `CompileSet` that contain C# code which will be included in the assembly.