### PR TITLE
handle assembly loading for full framework

### DIFF
--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -5,17 +5,13 @@ using Microsoft.CodeAnalysis;
 
 namespace RazorEngineCore
 {
+    using System;
+
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
     public class RazorEngineCompilationOptions
     {
-        public HashSet<Assembly> ReferencedAssemblies { get; set; } = new HashSet<Assembly>()
-        {
-            typeof(object).Assembly,
-            Assembly.Load(new AssemblyName("Microsoft.CSharp")),
-            typeof(RazorEngineTemplateBase).Assembly,
-            Assembly.Load(new AssemblyName("System.Runtime")),
-            Assembly.Load(new AssemblyName("System.Linq")),
-            Assembly.Load(new AssemblyName("System.Linq.Expressions"))
-        };
+        public HashSet<Assembly> ReferencedAssemblies { get; set; } = DefaultReferencedAssemblies();
 
         public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
         public string TemplateNamespace { get; set; } = "TemplateNamespace";
@@ -31,8 +27,44 @@ namespace RazorEngineCore
             // Loading netstandard explicitly causes runtime error on Linux/OSX
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                this.ReferencedAssemblies.Add(Assembly.Load(new AssemblyName("netstandard")));
+                if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.ReferencedAssemblies.Add(
+                        Assembly.Load(
+                            new AssemblyName(
+                                "netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51")));
+                }
+                else
+                {
+                    this.ReferencedAssemblies.Add(Assembly.Load(new AssemblyName("netstandard")));
+                }
             }
+        }
+
+        private static HashSet<Assembly> DefaultReferencedAssemblies()
+        {
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
+            {
+                return new HashSet<Assembly>()
+                           {
+                               typeof(object).Assembly,
+                               Assembly.Load(new AssemblyName("Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")),
+                               typeof(RazorEngineTemplateBase).Assembly,
+                               typeof(System.Runtime.GCSettings).Assembly,
+                               typeof(System.Linq.Enumerable).Assembly,
+                               typeof(System.Linq.Expressions.Expression).Assembly
+                           };
+            }
+
+            return new HashSet<Assembly>()
+                       {
+                           typeof(object).Assembly,
+                           Assembly.Load(new AssemblyName("Microsoft.CSharp")),
+                           typeof(RazorEngineTemplateBase).Assembly,
+                           Assembly.Load(new AssemblyName("System.Runtime")),
+                           Assembly.Load(new AssemblyName("System.Linq")),
+                           Assembly.Load(new AssemblyName("System.Linq.Expressions"))
+                       };
         }
     }
 }


### PR DESCRIPTION
When using the package in a .NET Framework 4.7.2 application it throws an FileNotFoundException on some assemblies from GAC e.g. Microsoft.CSharp and netstandard. This happens for example when using Program.cs from ExampleApp in a .NET Framework console app.

This seems to be because in .NET Framework Assembly.Load does not work from GAC with only the name but bascially requires a full name. The code in the Pull Request handles this by changing the loading of some assemblies when detecting full framework. For some assemblies it can be done by using types to load them. But unfortunately it has to sue specifing specific versions for some assemblies. At least that was the only way I go this to work.