### PR TITLE
Added the ability to debug templates is now available

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,31 @@ IRazorEngineCompiledTemplate compiledTemplate = razorEngine.Compile(templateText
 string result = compiledTemplate.Run(new { name = "Hello" });
 ```
 
+#### Debugging templates
+Add the following line in your template source and your debugger(vs code/vs studio) break on it.
+```cs
+System.Diagnostics.Debugger.Break();
+```
+Use this overload for the Compile function and pass true for the addPdb argument
+```cs
+razorEngine.Compile(templateSource, builder =>
+{
+    builder.AddAssemblyReferenceByName("System.Security"); // by name
+    builder.AddAssemblyReference(typeof(System.IO.File)); // by type
+    builder.AddAssemblyReference(Assembly.Load("source")); // by reference
+},
+true); //This 'true' will enable debugging.
+```
+Your debbuger will ask you to provide the path to the source file, by defult it is set to be generated in %temp% (point your there when asked for the file). 
+
 
 #### Credits
 This package is inspired by [Simon Mourier SO post](https://stackoverflow.com/a/47756437/267736)
 
 
 #### Changelog
+* 2021.10.28
+	* Added the option to genereate pdb alongside the assembly which allows debugging the templates.
 * 2021.7.1
 	* Better error messages #PR54 (thanks [@wdcossey](https://github.com/wdcossey))	
 	* More asyncs #PR53 (thanks [@wdcossey](https://github.com/wdcossey))

--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -10,9 +10,11 @@ namespace RazorEngineCore
         
         Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
             where T : IRazorEngineTemplate;
-        
+
         IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
-        
+
+        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null,bool addPdb=false);
+
         Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
     }
 }

--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -13,8 +13,6 @@ namespace RazorEngineCore
 
         IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
 
-        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null,bool addPdb=false);
-
         Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
     }
 }

--- a/RazorEngineCore/IRazorEngineCompilationOptionsBuilder.cs
+++ b/RazorEngineCore/IRazorEngineCompilationOptionsBuilder.cs
@@ -14,5 +14,6 @@ namespace RazorEngineCore
         void AddMetadataReference(MetadataReference reference);
         void AddUsing(string namespaceName);
         void Inherits(Type type);
+        void GeneratePdbSteram(bool flag);
     }
 }

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -34,15 +34,11 @@ namespace RazorEngineCore
         }
         public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
         {
-            return Compile(content,builderAction,false);
-        }
-        public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, bool addPdb = false)
-        {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
             compilationOptionsBuilder.Inherits(typeof(RazorEngineTemplateBase));
 
             builderAction?.Invoke(compilationOptionsBuilder);
-            if (addPdb)
+            if (compilationOptionsBuilder.Options.GeneratePdbSteram)
             {
                 MemoryStream pdbStream = new MemoryStream();
                 MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options, pdbStream);

--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -13,7 +13,8 @@ namespace RazorEngineCore
         public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
         public string TemplateNamespace { get; set; } = "TemplateNamespace";
         public string Inherits { get; set; } = "RazorEngineCore.RazorEngineTemplateBase";
-
+        ///Set to true to generate PDB symbols information along with the assembly for debugging support
+        public bool GeneratePdbSteram {get;set;} = false;
         public HashSet<string> DefaultUsings { get; set; } = new HashSet<string>()
         {
             "System.Linq",

--- a/RazorEngineCore/RazorEngineCompilationOptionsBuilder.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptionsBuilder.cs
@@ -67,5 +67,10 @@ namespace RazorEngineCore
 
             return result + "<" + string.Join(",", type.GenericTypeArguments.Select(this.RenderTypeName)) + ">";
         }
+
+        public void GeneratePdbSteram(bool flag)
+        {
+            this.Options.GeneratePdbSteram = flag;
+        }
     }
 }

--- a/RazorEngineCore/RazorEngineCompiledTemplate.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplate.cs
@@ -17,6 +17,13 @@ namespace RazorEngineCore
             Assembly assembly = Assembly.Load(assemblyByteCode.ToArray());
             this.templateType = assembly.GetType("TemplateNamespace.Template");
         }
+        internal RazorEngineCompiledTemplate(MemoryStream assemblyByteCode,MemoryStream pdbByteCode)
+        {
+            this.assemblyByteCode = assemblyByteCode;
+
+            Assembly assembly = Assembly.Load(assemblyByteCode.ToArray(), pdbByteCode.ToArray());
+            this.templateType = assembly.GetType("TemplateNamespace.Template");
+        }
 
         public static IRazorEngineCompiledTemplate LoadFromFile(string fileName)
         {

--- a/RazorEngineCore/RazorEngineCore.csproj
+++ b/RazorEngineCore/RazorEngineCore.csproj
@@ -24,6 +24,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="5.0.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added the ability to debug templates is now available
the template is saved to a temp folder and that is set as the project folder.
however you have to delete it manually for clean up later on.
The csharp scripting has been updated because I was using some features of the newer version that were not available in the previous versions.