### PR TITLE
Added ability to set the template filename

### DIFF
--- a/RazorEngineCore.Tests/TestTemplateFilename.cs
+++ b/RazorEngineCore.Tests/TestTemplateFilename.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RazorEngineCore.Tests
+{
+    [TestClass]
+    public class TestTemplateFilename
+    {
+        [TestMethod]
+        public void TestSettingTemplateFilename()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+            var errorThrown = false;
+            try
+            {
+                IRazorEngineCompiledTemplate initialTemplate = razorEngine.Compile("@{ this is a syntaxerror }", 
+                    builder => { builder.Options.TemplateFilename = "templatefilenameset.txt"; });
+            }
+            catch (Exception e)
+            {
+                Assert.IsTrue(e.Message.Contains("templatefilenameset.txt"));
+                errorThrown = true;
+            }
+
+            Assert.IsTrue(errorThrown);
+        }
+    }
+}

--- a/RazorEngineCore.Tests/TestTemplateNamespace.cs
+++ b/RazorEngineCore.Tests/TestTemplateNamespace.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RazorEngineCore.Tests.Models;
+
+namespace RazorEngineCore.Tests
+{
+    [TestClass]
+    public class TestTemplateNamespace
+    {
+        [TestMethod]
+        public void TestSettingTemplateNamespace()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+
+            IRazorEngineCompiledTemplate initialTemplate = razorEngine.Compile("@{ var message = \"OK\"; }@message",
+                builder => { builder.Options.TemplateNamespace = "Test.Namespace"; });
+
+            var result = initialTemplate.Run();
+
+            Assert.AreEqual("OK", result);
+        }
+
+        [TestMethod]
+        public void TestSettingTemplateNamespaceT()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+
+            var initialTemplate = razorEngine.Compile<TestTemplate2>("@{ var message = \"OK\"; }@message",
+                builder => { builder.Options.TemplateNamespace = "Test.Namespace"; });
+
+            var result = initialTemplate.Run(a => { });
+
+            Assert.AreEqual("OK", result);
+        }
+    }
+}

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -62,7 +62,7 @@ namespace RazorEngineCore
                     builder.SetNamespace(options.TemplateNamespace);
                 });
 
-            string fileName = Path.GetRandomFileName();
+            string fileName = string.IsNullOrWhiteSpace(options.TemplateFilename) ? Path.GetRandomFileName() : options.TemplateFilename;
 
             RazorSourceDocument document = RazorSourceDocument.Create(templateSource, fileName);
             

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -25,7 +25,7 @@ namespace RazorEngineCore
 
             MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
            
-            return new RazorEngineCompiledTemplate<T>(memoryStream);
+            return new RazorEngineCompiledTemplate<T>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
         public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate
@@ -42,7 +42,7 @@ namespace RazorEngineCore
 
             MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
 
-            return new RazorEngineCompiledTemplate(memoryStream);
+            return new RazorEngineCompiledTemplate(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
         public Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)

--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -12,6 +12,7 @@ namespace RazorEngineCore
 
         public HashSet<MetadataReference> MetadataReferences { get; set; } = new HashSet<MetadataReference>();
         public string TemplateNamespace { get; set; } = "TemplateNamespace";
+        public string TemplateFilename { get; set; } = "";
         public string Inherits { get; set; } = "RazorEngineCore.RazorEngineTemplateBase";
 
         public HashSet<string> DefaultUsings { get; set; } = new HashSet<string>()

--- a/RazorEngineCore/RazorEngineCompiledTemplate.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplate.cs
@@ -6,24 +6,24 @@ using System.Threading.Tasks;
 namespace RazorEngineCore
 {
     public class RazorEngineCompiledTemplate : IRazorEngineCompiledTemplate
-    {
+    {        
         private readonly MemoryStream assemblyByteCode;
         private readonly Type templateType;
 
-        internal RazorEngineCompiledTemplate(MemoryStream assemblyByteCode)
+        internal RazorEngineCompiledTemplate(MemoryStream assemblyByteCode, string templateNamespace)
         {
             this.assemblyByteCode = assemblyByteCode;
 
             Assembly assembly = Assembly.Load(assemblyByteCode.ToArray());
-            this.templateType = assembly.GetType("TemplateNamespace.Template");
+            this.templateType = assembly.GetType($"{templateNamespace}.Template");
         }
 
-        public static IRazorEngineCompiledTemplate LoadFromFile(string fileName)
+        public static IRazorEngineCompiledTemplate LoadFromFile(string fileName, string templateNamespace = "TemplateNamespace")
         {
-            return LoadFromFileAsync(fileName: fileName).GetAwaiter().GetResult();
+            return LoadFromFileAsync(fileName: fileName, templateNamespace: templateNamespace).GetAwaiter().GetResult();
         }
 
-        public static async Task<IRazorEngineCompiledTemplate> LoadFromFileAsync(string fileName)
+        public static async Task<IRazorEngineCompiledTemplate> LoadFromFileAsync(string fileName, string templateNamespace = "TemplateNamespace")
         {
             MemoryStream memoryStream = new MemoryStream();
             
@@ -38,7 +38,7 @@ namespace RazorEngineCore
                 await fileStream.CopyToAsync(memoryStream);
             }
             
-            return new RazorEngineCompiledTemplate(memoryStream);
+            return new RazorEngineCompiledTemplate(memoryStream, templateNamespace);
         }
         
         public static IRazorEngineCompiledTemplate LoadFromStream(Stream stream)
@@ -46,13 +46,13 @@ namespace RazorEngineCore
             return LoadFromStreamAsync(stream).GetAwaiter().GetResult();
         }
         
-        public static async Task<IRazorEngineCompiledTemplate> LoadFromStreamAsync(Stream stream)
+        public static async Task<IRazorEngineCompiledTemplate> LoadFromStreamAsync(Stream stream, string templateNamespace = "TemplateNamespace")
         {
             MemoryStream memoryStream = new MemoryStream();
             await stream.CopyToAsync(memoryStream);
             memoryStream.Position = 0;
             
-            return new RazorEngineCompiledTemplate(memoryStream);
+            return new RazorEngineCompiledTemplate(memoryStream, templateNamespace);
         }
 
         public void SaveToStream(Stream stream)

--- a/RazorEngineCore/RazorEngineCompiledTemplateT.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplateT.cs
@@ -10,20 +10,20 @@ namespace RazorEngineCore
         private readonly MemoryStream assemblyByteCode;
         private readonly Type templateType;
 
-        internal RazorEngineCompiledTemplate(MemoryStream assemblyByteCode)
+        internal RazorEngineCompiledTemplate(MemoryStream assemblyByteCode, string templateNamespace)
         {
             this.assemblyByteCode = assemblyByteCode;
 
             Assembly assembly = Assembly.Load(assemblyByteCode.ToArray());
-            this.templateType = assembly.GetType("TemplateNamespace.Template");
+            this.templateType = assembly.GetType($"{templateNamespace}.Template");
         }
 
-        public static IRazorEngineCompiledTemplate<T> LoadFromFile(string fileName)
+        public static IRazorEngineCompiledTemplate<T> LoadFromFile(string fileName, string templateNamespace = "TemplateNamespace")
         {
-            return LoadFromFileAsync(fileName: fileName).GetAwaiter().GetResult();
+            return LoadFromFileAsync(fileName: fileName, templateNamespace: templateNamespace).GetAwaiter().GetResult();
         }
         
-        public static async Task<IRazorEngineCompiledTemplate<T>> LoadFromFileAsync(string fileName)
+        public static async Task<IRazorEngineCompiledTemplate<T>> LoadFromFileAsync(string fileName, string templateNamespace = "TemplateNamespace")
         {
             MemoryStream memoryStream = new MemoryStream();
             
@@ -38,7 +38,7 @@ namespace RazorEngineCore
                 await fileStream.CopyToAsync(memoryStream);
             }
             
-            return new RazorEngineCompiledTemplate<T>(memoryStream);
+            return new RazorEngineCompiledTemplate<T>(memoryStream, templateNamespace);
         }
 
         public static IRazorEngineCompiledTemplate<T> LoadFromStream(Stream stream)
@@ -46,13 +46,13 @@ namespace RazorEngineCore
             return LoadFromStreamAsync(stream).GetAwaiter().GetResult();
         }
         
-        public static async Task<IRazorEngineCompiledTemplate<T>> LoadFromStreamAsync(Stream stream)
+        public static async Task<IRazorEngineCompiledTemplate<T>> LoadFromStreamAsync(Stream stream, string templateNamespace = "TemplateNamespace")
         {
             MemoryStream memoryStream = new MemoryStream();
             await stream.CopyToAsync(memoryStream);
             memoryStream.Position = 0;
             
-            return new RazorEngineCompiledTemplate<T>(memoryStream);
+            return new RazorEngineCompiledTemplate<T>(memoryStream, templateNamespace);
         }
 
         public void SaveToStream(Stream stream)


### PR DESCRIPTION
Adds RazorEngineCompilationOptions.TemplateFilename, which is used if not empty or whitespace. If it is it falls back to the existing Path.GetRandomFilename().

This is helpful for debugging which templates are causing errors as we can pass the error to to the user without additional information.