### PR TITLE
Make private methods in RazorEngine protected and virtual

### DIFF
--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -16,14 +16,14 @@ namespace RazorEngineCore
         public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
-            
+
             compilationOptionsBuilder.AddAssemblyReference(typeof(T).Assembly);
             compilationOptionsBuilder.Inherits(typeof(T));
 
             builderAction?.Invoke(compilationOptionsBuilder);
 
             MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
-           
+
             return new RazorEngineCompiledTemplate<T>(memoryStream);
         }
 
@@ -36,7 +36,7 @@ namespace RazorEngineCore
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
             compilationOptionsBuilder.Inherits(typeof(RazorEngineTemplateBase));
-             
+
             builderAction?.Invoke(compilationOptionsBuilder);
 
             MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
@@ -48,8 +48,8 @@ namespace RazorEngineCore
         {
             return Task.Factory.StartNew(() => this.Compile(content: content, builderAction: builderAction));
         }
-        
-        private MemoryStream CreateAndCompileToStream(string templateSource, RazorEngineCompilationOptions options)
+
+        protected virtual MemoryStream CreateAndCompileToStream(string templateSource, RazorEngineCompilationOptions options)
         {
             templateSource = this.WriteDirectives(templateSource, options);
 
@@ -64,7 +64,7 @@ namespace RazorEngineCore
             string fileName = Path.GetRandomFileName();
 
             RazorSourceDocument document = RazorSourceDocument.Create(templateSource, fileName);
-            
+
             RazorCodeDocument codeDocument = engine.Process(
                 document,
                 null,
@@ -105,7 +105,7 @@ namespace RazorEngineCore
             return memoryStream;
         }
 
-        private string WriteDirectives(string content, RazorEngineCompilationOptions options)
+        protected virtual string WriteDirectives(string content, RazorEngineCompilationOptions options)
         {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.AppendLine($"@inherits {options.Inherits}");


### PR DESCRIPTION
Make private methods in `RazorEngine` `protected` and `virtual` to allow extending in inherited classes.