### PR TITLE
Added support for writing binary content to output 

### DIFF
--- a/ExampleAppCore/ExampleAppCore.csproj
+++ b/ExampleAppCore/ExampleAppCore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+	  <LangVersion>latest</LangVersion>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 

--- a/ExampleAppCore/ExampleAppCore.csproj
+++ b/ExampleAppCore/ExampleAppCore.csproj
@@ -13,10 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\RazorEngineCore\RazorEngineCore.csproj" />
   </ItemGroup>
 

--- a/ExampleAppCore/Program.cs
+++ b/ExampleAppCore/Program.cs
@@ -1,15 +1,120 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
 using System.Text;
+using System.Threading.Tasks;
 using RazorEngineCore;
 
 namespace ExampleApp
 {
-    public class TestModel : RazorEngineTemplateBase
+    public abstract class BinaryDataEngineTemplateBase<T> : BinaryDataEngineTemplateBase
+    {
+        public new T Model { get; set; }
+    }
+
+    public class BinaryDataEngineTemplateBase : IRazorEngineTemplate<byte[]>
+    {
+        readonly MemoryStream binaryWriter = new();
+
+        Encoding encoding = Encoding.UTF8;
+
+        private string attributeSuffix = null;
+
+        public dynamic Model { get; set; }
+
+        public void WriteLiteral(string literal = null)
+        {
+            WriteLiteralAsync(literal).GetAwaiter().GetResult();
+        }
+
+        public virtual Task WriteLiteralAsync(string literal = null)
+        {
+            Write(literal);
+            return Task.CompletedTask;
+        }
+
+        public void Write(object obj = null)
+        {
+            WriteAsync(obj).GetAwaiter().GetResult();
+        }
+
+        public virtual Task WriteAsync(object obj = null)
+        {
+            if (obj is byte[] bytes)
+                binaryWriter.Write(bytes);
+            else
+                binaryWriter.Write( encoding.GetBytes(obj.ToString()));
+            return Task.CompletedTask;
+        }
+
+        public void BeginWriteAttribute(string name, string prefix, int prefixOffset, string suffix, int suffixOffset,
+            int attributeValuesCount)
+        {
+            BeginWriteAttributeAsync(name, prefix, prefixOffset, suffix, suffixOffset, attributeValuesCount).GetAwaiter().GetResult();
+        }
+
+        public virtual Task BeginWriteAttributeAsync(string name, string prefix, int prefixOffset, string suffix, int suffixOffset, int attributeValuesCount)
+        {
+            this.attributeSuffix = suffix;
+            Write(prefix);
+            return Task.CompletedTask;
+        }
+
+        public void WriteAttributeValue(string prefix, int prefixOffset, object value, int valueOffset, int valueLength,
+            bool isLiteral)
+        {
+            WriteAttributeValueAsync(prefix, prefixOffset, value, valueOffset, valueLength, isLiteral).GetAwaiter().GetResult();
+        }
+
+        public virtual Task WriteAttributeValueAsync(string prefix, int prefixOffset, object value, int valueOffset, int valueLength, bool isLiteral)
+        {
+            Write(prefix);
+            Write(value);
+            return Task.CompletedTask;
+        }
+
+        public void EndWriteAttribute()
+        {
+            EndWriteAttributeAsync().GetAwaiter().GetResult();
+        }
+
+        public virtual Task EndWriteAttributeAsync()
+        {
+            Write(attributeSuffix);
+            this.attributeSuffix = null;
+            return Task.CompletedTask;
+        }
+
+        public void Execute()
+        {
+            ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public virtual Task ExecuteAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual byte[] Result()
+        {
+            return ResultAsync().GetAwaiter().GetResult();
+        }
+
+        public virtual Task<byte[]> ResultAsync()
+        {
+            return Task.FromResult<byte[]>( binaryWriter.ToArray() );
+        }
+    }
+
+    public class TestModel : BinaryDataEngineTemplateBase<TestModel>
     {
         public string Name { get; set; }
-        public IEnumerable<int> Items { get; set; }
+        public IEnumerable<string> Items { get; set; }
+        public byte[] BinaryData { get; set; }
     }
+
+
 
     class Program
     {
@@ -31,9 +136,12 @@ Hello @Model.Name
 @testheader
 @foreach(var myitem in @myitems)
 {
-    @myitem
+   <text>|  @(myitem)   |  @(myitem)    |   @(myitem)   |
+</text>
 }
-
+Binary data below:
+@Model.BinaryData
+End of Binary data
 
 <div data-name=""@Model.Name""></div>
 
@@ -56,27 +164,32 @@ Hello @Model.Name
         static void Main(string[] args)
         {
             IRazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile(Content);
+            var template = razorEngine.Compile<BinaryDataEngineTemplateBase<TestModel>, byte[]>(Content);
 
             /*
             StringBuilder stringBuilder = new StringBuilder();
             byte[] somebytes = { 0x02, 0x04, 0x50 };
             stringBuilder.Append(somebytes);
-
+            
             var s = stringBuilder.ToString();
             */
 
-            string result = template.Run(new
+            TestModel model = new TestModel()
             {
                 Name = "Alexander",
                 Items = new List<string>()
                 {
                     "item 1",
                     "item 2"
-                }
-            });
+                },
+                BinaryData = new byte[10] { 0x41, 0x0A, 0x0D, 0x00, 0x30, 0x31, 0x00, 0x0A, 0x0D, 0x41 } 
+            };
 
-            Console.WriteLine(result);
+
+
+            byte[] result = template.Run(instance => instance.Model = model);
+
+            Console.WriteLine(Encoding.UTF8.GetString(result));
             Console.ReadKey();
         }
     }

--- a/ExampleAppCore/Program.cs
+++ b/ExampleAppCore/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using RazorEngineCore;
 
 namespace ExampleApp
@@ -10,16 +11,29 @@ namespace ExampleApp
         public IEnumerable<int> Items { get; set; }
     }
 
-
     class Program
     {
-        static string Content = @"
+        static readonly string Content = @"
 Hello @Model.Name
+
+@{
+    string testheader = "" ---------------- mytest: will show the modified items ----------- "";
+    List<string> myitems = new ();
+    foreach (var item in Model.Items) {
+        myitems.Add("" ---->>>> "" + item);
+    }
+}
 
 @foreach(var item in @Model.Items)
 {
     <div>- @item</div>
 }
+@testheader
+@foreach(var myitem in @myitems)
+{
+    @myitem
+}
+
 
 <div data-name=""@Model.Name""></div>
 
@@ -42,7 +56,15 @@ Hello @Model.Name
         static void Main(string[] args)
         {
             IRazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile(Content);
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile(Content);
+
+            /*
+            StringBuilder stringBuilder = new StringBuilder();
+            byte[] somebytes = { 0x02, 0x04, 0x50 };
+            stringBuilder.Append(somebytes);
+
+            var s = stringBuilder.ToString();
+            */
 
             string result = template.Run(new
             {

--- a/ExampleAppNET5/Program.cs
+++ b/ExampleAppNET5/Program.cs
@@ -38,7 +38,7 @@ Hello @Model.Name
         static void Main(string[] args)
         {
             IRazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile(Content);
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile(Content);
 
             string result = template.Run(new
             {

--- a/ExampleAppNet472/Program.cs
+++ b/ExampleAppNet472/Program.cs
@@ -45,7 +45,7 @@ Hello @Model.Name
         static void Main(string[] args)
         {
             IRazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile(Content);
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile(Content);
 
             string result = template.Run(
                 new

--- a/RazorEngineCore.Tests/Models/TestTemplate1.cs
+++ b/RazorEngineCore.Tests/Models/TestTemplate1.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace RazorEngineCore.Tests.Models
 {
-    public class TestTemplate1 : RazorEngineTemplateBase
+    public class TestTemplate1 : RazorEngineTemplateBase<string>
     {
         public int A { get; set; }
         public int B { get; set; }

--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -35,7 +35,7 @@ namespace RazorEngineCore.Tests
         public void TestCompileAndRun_HtmlLiteral()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile("<h1>Hello @Model.Name</h1>");
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile("<h1>Hello @Model.Name</h1>");
 
             string actual = template.Run(new
             {
@@ -49,7 +49,7 @@ namespace RazorEngineCore.Tests
         public async Task TestCompileAndRun_HtmlLiteralAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("<h1>Hello @Model.Name</h1>");
+            IRazorEngineCompiledTemplate<string> template = await razorEngine.CompileAsync("<h1>Hello @Model.Name</h1>");
 
             string actual = await template.RunAsync(new
             {
@@ -63,7 +63,7 @@ namespace RazorEngineCore.Tests
         public void TestCompileAndRun_InAttributeVariables()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile("<div class=\"circle\" style=\"background-color: hsla(@Model.Colour, 70%,   80%,1);\">");
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile("<div class=\"circle\" style=\"background-color: hsla(@Model.Colour, 70%,   80%,1);\">");
 
             string actual = template.Run(new
             {
@@ -77,7 +77,7 @@ namespace RazorEngineCore.Tests
         public void TestCompileAndRun_InAttributeVariables2()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile("<img src='@(\"test\")'>");
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile("<img src='@(\"test\")'>");
 
             string actual = template.Run(new
             {
@@ -91,7 +91,7 @@ namespace RazorEngineCore.Tests
         public async Task TestCompileAndRun_InAttributeVariablesAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("<div class=\"circle\" style=\"background-color: hsla(@Model.Colour, 70%,   80%,1);\">");
+            IRazorEngineCompiledTemplate<string> template = await razorEngine.CompileAsync("<div class=\"circle\" style=\"background-color: hsla(@Model.Colour, 70%,   80%,1);\">");
 
             string actual = await template.RunAsync(new
             {
@@ -105,7 +105,7 @@ namespace RazorEngineCore.Tests
         public void TestCompileAndRun_HtmlAttribute()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile("<div title=\"@Model.Name\">Hello</div>");
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile("<div title=\"@Model.Name\">Hello</div>");
 
             string actual = template.Run(new
             {
@@ -119,7 +119,7 @@ namespace RazorEngineCore.Tests
         public async Task TestCompileAndRun_HtmlAttributeAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("<div title=\"@Model.Name\">Hello</div>");
+            IRazorEngineCompiledTemplate<string> template = await razorEngine.CompileAsync("<div title=\"@Model.Name\">Hello</div>");
 
             string actual = await template.RunAsync(new
             {
@@ -133,7 +133,7 @@ namespace RazorEngineCore.Tests
         public void TestCompileAndRun_DynamicModel_Plain()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile("Hello @Model.Name");
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile("Hello @Model.Name");
 
             string actual = template.Run(new
             {
@@ -147,7 +147,7 @@ namespace RazorEngineCore.Tests
         public async Task TestCompileAndRun_DynamicModel_PlainAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("Hello @Model.Name");
+            IRazorEngineCompiledTemplate<string> template = await razorEngine.CompileAsync("Hello @Model.Name");
 
             string actual = await template.RunAsync(new
             {
@@ -218,7 +218,7 @@ namespace RazorEngineCore.Tests
 
             DateTime? dateTime = DateTime.Now;
 
-            IRazorEngineCompiledTemplate<TestTemplate2> template = razorEngine.Compile<TestTemplate2>("DateTime: @Model.DateTime.Value.ToString()");
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = razorEngine.Compile<TestTemplate2>("DateTime: @Model.DateTime.Value.ToString()");
 
             string actual = template.Run(instance => instance.Model = new TestModel()
             {
@@ -235,7 +235,7 @@ namespace RazorEngineCore.Tests
 
             DateTime? dateTime = null;
 
-            IRazorEngineCompiledTemplate<TestTemplate2> template = razorEngine.Compile<TestTemplate2>("DateTime: @Model.DateTime");
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = razorEngine.Compile<TestTemplate2>("DateTime: @Model.DateTime");
 
             string actual = template.Run(instance => instance.Model = new TestModel()
             {
@@ -459,7 +459,7 @@ void RecursionTest(int level)
         public void TestCompileAndRun_TypedModel1()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate1> template = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")");
+            IRazorEngineCompiledTemplate<TestTemplate1, string> template = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")");
 
             string actual = template.Run(instance =>
             {
@@ -475,7 +475,7 @@ void RecursionTest(int level)
         public async Task TestCompileAndRun_TypedModel1Async()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate1> template = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")");
+            IRazorEngineCompiledTemplate<TestTemplate1, string> template = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")");
 
             string actual = await template.RunAsync(instance =>
             {
@@ -491,7 +491,7 @@ void RecursionTest(int level)
         public void TestCompileAndRun_TypedModel2()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate2> template = razorEngine.Compile<TestTemplate2>("Hello @Model.Decorator(Model.C)");
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = razorEngine.Compile<TestTemplate2>("Hello @Model.Decorator(Model.C)");
 
             string actual = template.Run(instance =>
             {
@@ -513,7 +513,7 @@ Hello @Model.Decorator(Model.C)
 ";
 
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<RazorEngineTemplateBase<TestModel>> template = razorEngine.Compile<RazorEngineTemplateBase<TestModel>>(templateText);
+            IRazorEngineCompiledTemplate<RazorEngineTemplateBase<TestModel>, string> template = razorEngine.Compile<RazorEngineTemplateBase<TestModel>>(templateText);
 
             string actual = template.Run(instance =>
             {
@@ -530,7 +530,7 @@ Hello @Model.Decorator(Model.C)
         public async Task TestCompileAndRun_TypedModel2Async()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate2> template = await razorEngine.CompileAsync<TestTemplate2>("Hello @Model.Decorator(Model.C)");
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = await razorEngine.CompileAsync<TestTemplate2>("Hello @Model.Decorator(Model.C)");
 
             string actual = await template.RunAsync(instance =>
             {
@@ -547,7 +547,7 @@ Hello @Model.Decorator(Model.C)
         public void TestCompileAndRun_AnonymousModelWithArrayOfObjects()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate2> template = razorEngine.Compile<TestTemplate2>(
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = razorEngine.Compile<TestTemplate2>(
 @"
 @foreach (var item in Model.Numbers.OrderByDescending(x => x))
 {
@@ -575,7 +575,7 @@ Hello @Model.Decorator(Model.C)
         public void TestCompileAndRun_StronglyTypedModelLinq()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate2> template = razorEngine.Compile<TestTemplate2>(
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = razorEngine.Compile<TestTemplate2>(
 @"
 @foreach (var item in Model.Numbers.OrderByDescending(x => x))
 {
@@ -602,7 +602,7 @@ Hello @Model.Decorator(Model.C)
         public void TestCompileAndRun_DynamicModelLinq()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = razorEngine.Compile(
+            IRazorEngineCompiledTemplate<string> template = razorEngine.Compile(
 @"
 @foreach (var item in ((IEnumerable<object>)Model.Numbers).OrderByDescending(x => x))
 {
@@ -626,7 +626,7 @@ Hello @Model.Decorator(Model.C)
         public async Task TestCompileAndRun_LinqAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate<TestTemplate2> template = await razorEngine.CompileAsync<TestTemplate2>(
+            IRazorEngineCompiledTemplate<TestTemplate2, string> template = await razorEngine.CompileAsync<TestTemplate2>(
 @"
 @foreach (var item in Model.Numbers.OrderByDescending(x => x))
 {
@@ -693,7 +693,7 @@ namespace TestAssembly
                             : null;
 
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync(@"
+            IRazorEngineCompiledTemplate<string> template = await razorEngine.CompileAsync(@"
 @using TestAssembly
 <p>@Greeting.GetGreeting(""Name"")</p>
 ", builder =>

--- a/RazorEngineCore.Tests/TestSaveLoad.cs
+++ b/RazorEngineCore.Tests/TestSaveLoad.cs
@@ -11,13 +11,13 @@ namespace RazorEngineCore.Tests
         public void TestSaveToStream()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate initialTemplate = razorEngine.Compile("Hello @Model.Name");
+            IRazorEngineCompiledTemplate<string> initialTemplate = razorEngine.Compile("Hello @Model.Name");
             
             MemoryStream memoryStream = new MemoryStream();
             initialTemplate.SaveToStream(memoryStream);
             memoryStream.Position = 0;
 
-            IRazorEngineCompiledTemplate loadedTemplate = RazorEngineCompiledTemplate.LoadFromStream(memoryStream);
+            IRazorEngineCompiledTemplate<string> loadedTemplate = RazorEngineCompiledTemplate<string>.LoadFromStream(memoryStream);
 
             string initialTemplateResult = initialTemplate.Run(new { Name = "Alex" });
             string loadedTemplateResult = loadedTemplate.Run(new { Name = "Alex" });
@@ -29,13 +29,13 @@ namespace RazorEngineCore.Tests
         public async Task TestSaveToStreamAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate initialTemplate = await razorEngine.CompileAsync("Hello @Model.Name");
+            IRazorEngineCompiledTemplate<string> initialTemplate = await razorEngine.CompileAsync("Hello @Model.Name");
             
             MemoryStream memoryStream = new MemoryStream();
             await initialTemplate.SaveToStreamAsync(memoryStream);
             memoryStream.Position = 0;
 
-            IRazorEngineCompiledTemplate loadedTemplate = await RazorEngineCompiledTemplate.LoadFromStreamAsync(memoryStream);
+            IRazorEngineCompiledTemplate<string> loadedTemplate = await RazorEngineCompiledTemplate<string>.LoadFromStreamAsync(memoryStream);
 
             string initialTemplateResult = await initialTemplate.RunAsync(new { Name = "Alex" });
             string loadedTemplateResult = await loadedTemplate.RunAsync(new { Name = "Alex" });
@@ -47,11 +47,11 @@ namespace RazorEngineCore.Tests
         public void TestSaveToFile()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate initialTemplate = razorEngine.Compile("Hello @Model.Name");
+            IRazorEngineCompiledTemplate<string> initialTemplate = razorEngine.Compile("Hello @Model.Name");
             
             initialTemplate.SaveToFile("testTemplate.dll");
 
-            IRazorEngineCompiledTemplate loadedTemplate = RazorEngineCompiledTemplate.LoadFromFile("testTemplate.dll");
+            IRazorEngineCompiledTemplate<string> loadedTemplate = RazorEngineCompiledTemplate<string>.LoadFromFile("testTemplate.dll");
 
             string initialTemplateResult = initialTemplate.Run(new { Name = "Alex" });
             string loadedTemplateResult = loadedTemplate.Run(new { Name = "Alex" });
@@ -63,11 +63,11 @@ namespace RazorEngineCore.Tests
         public async Task TestSaveToFileAsync()
         {
             RazorEngine razorEngine = new RazorEngine();
-            IRazorEngineCompiledTemplate initialTemplate = await razorEngine.CompileAsync("Hello @Model.Name");
+            IRazorEngineCompiledTemplate<string> initialTemplate = await razorEngine.CompileAsync("Hello @Model.Name");
             
             await initialTemplate.SaveToFileAsync("testTemplate.dll");
 
-            IRazorEngineCompiledTemplate loadedTemplate = await RazorEngineCompiledTemplate.LoadFromFileAsync("testTemplate.dll");
+            IRazorEngineCompiledTemplate<string> loadedTemplate = await RazorEngineCompiledTemplate<string>.LoadFromFileAsync("testTemplate.dll");
 
             string initialTemplateResult = await initialTemplate.RunAsync(new { Name = "Alex" });
             string loadedTemplateResult = await loadedTemplate.RunAsync(new { Name = "Alex" });

--- a/RazorEngineCore.Tests/TestTemplateFilename.cs
+++ b/RazorEngineCore.Tests/TestTemplateFilename.cs
@@ -15,7 +15,7 @@ namespace RazorEngineCore.Tests
             var errorThrown = false;
             try
             {
-                IRazorEngineCompiledTemplate initialTemplate = razorEngine.Compile("@{ this is a syntaxerror }", 
+                IRazorEngineCompiledTemplate<string> initialTemplate = razorEngine.Compile("@{ this is a syntaxerror }", 
                     builder => { builder.Options.TemplateFilename = "templatefilenameset.txt"; });
             }
             catch (Exception e)

--- a/RazorEngineCore.Tests/TestTemplateNamespace.cs
+++ b/RazorEngineCore.Tests/TestTemplateNamespace.cs
@@ -14,7 +14,7 @@ namespace RazorEngineCore.Tests
         {
             RazorEngine razorEngine = new RazorEngine();
 
-            IRazorEngineCompiledTemplate initialTemplate = razorEngine.Compile("@{ var message = \"OK\"; }@message",
+            IRazorEngineCompiledTemplate<string> initialTemplate = razorEngine.Compile("@{ var message = \"OK\"; }@message",
                 builder => { builder.Options.TemplateNamespace = "Test.Namespace"; });
 
             var result = initialTemplate.Run();

--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -6,11 +6,13 @@ namespace RazorEngineCore
 {
     public interface IRazorEngine
     {
-        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
-            where T : IRazorEngineTemplate<T>;
+        IRazorEngineCompiledTemplate<T, R> Compile<T, R>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
+            where T : IRazorEngineTemplate<R>;
+        IRazorEngineCompiledTemplate<T, string> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
+            where T : IRazorEngineTemplate<string>;
         
-        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
-            where T : IRazorEngineTemplate<T>;
+        Task<IRazorEngineCompiledTemplate<T, string>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
+            where T : IRazorEngineTemplate<string>;
         
         IRazorEngineCompiledTemplate<string> Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
         

--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO.Pipelines;
 using System.Threading.Tasks;
 
 namespace RazorEngineCore
@@ -6,13 +7,14 @@ namespace RazorEngineCore
     public interface IRazorEngine
     {
         IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
-            where T : IRazorEngineTemplate;
+            where T : IRazorEngineTemplate<T>;
         
         Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
-            where T : IRazorEngineTemplate;
+            where T : IRazorEngineTemplate<T>;
         
-        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
+        IRazorEngineCompiledTemplate<string> Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
         
-        Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
+        Task<IRazorEngineCompiledTemplate<string>> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
+
     }
 }

--- a/RazorEngineCore/IRazorEngineCompiledTemplate.cs
+++ b/RazorEngineCore/IRazorEngineCompiledTemplate.cs
@@ -3,13 +3,13 @@ using System.Threading.Tasks;
 
 namespace RazorEngineCore
 {
-    public interface IRazorEngineCompiledTemplate
+    public interface IRazorEngineCompiledTemplate<R>
     {
         void SaveToStream(Stream stream);
         Task SaveToStreamAsync(Stream stream);
         void SaveToFile(string fileName);
         Task SaveToFileAsync(string fileName);
-        string Run(object model = null);
-        Task<string> RunAsync(object model = null);
+        R Run(object model = null);
+        Task<R> RunAsync(object model = null);
     }
 }

--- a/RazorEngineCore/IRazorEngineCompiledTemplateT.cs
+++ b/RazorEngineCore/IRazorEngineCompiledTemplateT.cs
@@ -4,13 +4,13 @@ using System.Threading.Tasks;
 
 namespace RazorEngineCore
 {
-    public interface IRazorEngineCompiledTemplate<out T> where T : IRazorEngineTemplate
+    public interface IRazorEngineCompiledTemplate<out T, R> where T : IRazorEngineTemplate<R>
     {
         void SaveToStream(Stream stream);
         Task SaveToStreamAsync(Stream stream);
         void SaveToFile(string fileName);
         Task SaveToFileAsync(string fileName);
-        string Run(Action<T> initializer);
-        Task<string> RunAsync(Action<T> initializer);
+        R Run(Action<T> initializer);
+        Task<R> RunAsync(Action<T> initializer);
     }
 }

--- a/RazorEngineCore/IRazorEngineTemplate.cs
+++ b/RazorEngineCore/IRazorEngineTemplate.cs
@@ -2,7 +2,7 @@
 
 namespace RazorEngineCore
 {
-    public interface IRazorEngineTemplate
+    public interface IRazorEngineTemplate<T>
     {
         dynamic Model { get; set; }
         void WriteLiteral(string literal = null);
@@ -29,8 +29,8 @@ namespace RazorEngineCore
         
         Task ExecuteAsync();
         
-        string Result();
+        T Result();
         
-        Task<string> ResultAsync();
+        Task<T> ResultAsync();
     }
 }

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -14,7 +14,7 @@ namespace RazorEngineCore
 {
     public class RazorEngine : IRazorEngine
     {
-        public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate
+        public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<R>
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
 
@@ -28,12 +28,12 @@ namespace RazorEngineCore
             return new RazorEngineCompiledTemplate<T>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
-        public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate
+        public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<string>
         {
             return Task.Factory.StartNew(() => this.Compile<T>(content: content, builderAction: builderAction));
         }
 
-        public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
+        public IRazorEngineCompiledTemplate<string> Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
             compilationOptionsBuilder.Inherits(typeof(RazorEngineTemplateBase));
@@ -42,10 +42,10 @@ namespace RazorEngineCore
 
             MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
 
-            return new RazorEngineCompiledTemplate(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
+            return new RazorEngineCompiledTemplate<string>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
-        public Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
+        public Task<IRazorEngineCompiledTemplate<string>> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
         {
             return Task.Factory.StartNew(() => this.Compile(content: content, builderAction: builderAction));
         }
@@ -103,13 +103,13 @@ namespace RazorEngineCore
                     .ToList(),
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-            MemoryStream memoryStream = new MemoryStream();
+            MemoryStream memoryStream = new();
 
             EmitResult emitResult = compilation.Emit(memoryStream);
 
             if (!emitResult.Success)
             {
-                RazorEngineCompilationException exception = new RazorEngineCompilationException()
+                RazorEngineCompilationException exception = new()
                 {
                     Errors = emitResult.Diagnostics.ToList(),
                     GeneratedCode = razorCSharpDocument.GeneratedCode
@@ -125,7 +125,7 @@ namespace RazorEngineCore
 
         protected virtual string WriteDirectives(string content, RazorEngineCompilationOptions options)
         {
-            StringBuilder stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new();
             stringBuilder.AppendLine($"@inherits {options.Inherits}");
 
             foreach (string entry in options.DefaultUsings)

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -14,7 +14,7 @@ namespace RazorEngineCore
 {
     public class RazorEngine : IRazorEngine
     {
-        public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<R>
+        public IRazorEngineCompiledTemplate<T, R> Compile<T, R>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<R>
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
 
@@ -25,10 +25,24 @@ namespace RazorEngineCore
 
             MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
 
-            return new RazorEngineCompiledTemplate<T>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
+            return new RazorEngineCompiledTemplate<T, R>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
-        public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<string>
+        public IRazorEngineCompiledTemplate<T, string> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<string>
+        {
+            IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
+
+            compilationOptionsBuilder.AddAssemblyReference(typeof(T).Assembly);
+            compilationOptionsBuilder.Inherits(typeof(T));
+
+            builderAction?.Invoke(compilationOptionsBuilder);
+
+            MemoryStream memoryStream = this.CreateAndCompileToStream(content, compilationOptionsBuilder.Options);
+
+            return new RazorEngineCompiledTemplate<T, string>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
+        }
+
+        public Task<IRazorEngineCompiledTemplate<T, string>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate<string>
         {
             return Task.Factory.StartNew(() => this.Compile<T>(content: content, builderAction: builderAction));
         }
@@ -137,5 +151,7 @@ namespace RazorEngineCore
 
             return stringBuilder.ToString();
         }
+
+        
     }
 }

--- a/RazorEngineCore/RazorEngineCore.csproj
+++ b/RazorEngineCore/RazorEngineCore.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+	  <LangVersion>latest</LangVersion>
     <TargetFrameworks>net6.0;net5.0;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>2022.1.2</Version>
@@ -22,5 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
   </ItemGroup>
 </Project>

--- a/RazorEngineCore/RazorEngineTemplateBase.cs
+++ b/RazorEngineCore/RazorEngineTemplateBase.cs
@@ -3,9 +3,9 @@ using System.Threading.Tasks;
 
 namespace RazorEngineCore
 {
-    public abstract class RazorEngineTemplateBase : IRazorEngineTemplate
+    public abstract class RazorEngineTemplateBase : IRazorEngineTemplate<string>
     {
-        private readonly StringBuilder stringBuilder = new StringBuilder();
+        private readonly StringBuilder stringBuilder = new();
 
         private string attributeSuffix = null;
 


### PR DESCRIPTION
This pull is in relation to the issue here: https://github.com/adoconnection/RazorEngineCore/issues/98

For my use-case I need to be able to write blocks of binary data to output files and without this change it is virtually impossible to achieve.

This change also opens various other possibilities, such as writing to a Stream or PipeWriter instead and returing a PipeReader to get the content from, which would improve efficiency for generation of very large output files.
