### PR TITLE
Fix AnonymousTypeWrapper cast failing on lists of structs

### DIFF
--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -157,6 +157,24 @@ namespace RazorEngineCore.Tests
             Assert.AreEqual("Hello Alex", actual);
         }
 
+        public struct Item
+        {
+            public string Name { get; set; }
+        }
+
+        [TestMethod]
+        public void TestCompileAndRun_StructList()
+        {
+            var eng = new RazorEngine();
+            var model = new
+            {
+                Items = new[] { new Item { Name = "Bob" }, new Item { Name = "Alice" } }
+            };
+            var temp = eng.Compile("@foreach(var item in Model.Items) { @item.Name }");
+            var result = temp.Run(model);
+            Assert.AreEqual("BobAlice", result);
+        }
+
         [TestMethod]
         public void TestCompileAndRun_DynamicModel_Nested()
         {

--- a/RazorEngineCore/AnonymousTypeWrapper.cs
+++ b/RazorEngineCore/AnonymousTypeWrapper.cs
@@ -39,8 +39,6 @@ namespace RazorEngineCore
                 result = new AnonymousTypeWrapper(result);
             }
 
-            bool isEnumerable = typeof(IEnumerable).IsAssignableFrom(type);
-
             if (result is IDictionary dictionary)
             {
                 List<object> keys = new List<object>();
@@ -58,9 +56,9 @@ namespace RazorEngineCore
                     }
                 }
             }
-            else if (isEnumerable && !(result is string))
+            else if (result is IEnumerable enumer && !(result is string))
             {
-                result = ((IEnumerable<object>)result)
+                result = enumer.Cast<object>()
                         .Select(e =>
                         {
                             if (e.IsAnonymous())


### PR DESCRIPTION
This code:
```
using RazorEngineCore;

var eng = new RazorEngine();

var content = @"Your favourite colors are: 
@foreach(var color in Model.Colors) {
    @color.Name
}
";

var templ = eng.Compile(content);

var model = new
{
    Colors = new List<Color>()
    {
        new Color { Name = "Green" },
        new Color { Name = "Red" }
    }
};

var result = templ.Run(model);

Console.Write(result);

public struct Color
{
    public string Name { get; set; }
}
```

Currently throws this exception:
```
System.InvalidCastException: 'Unable to cast object of type 'System.Collections.Generic.List`1[Color]' to type 'System.Collections.Generic.IEnumerable`1[System.Object]'.'
```