### PR TITLE
Add CancellationToken overloads to Compile methods

### DIFF
--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -13,6 +13,7 @@ using RazorEngineCore.Tests.Models;
 namespace RazorEngineCore.Tests
 {
     using System.Runtime.InteropServices;
+    using System.Threading;
 
     [TestClass]
     public class TestCompileAndRun
@@ -726,6 +727,66 @@ namespace TestAssembly
             string actual = await template.RunAsync();
 
             Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestCompileCancellation_DynamicModel()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+            using (CancellationTokenSource cancellationSource = new CancellationTokenSource())
+            {
+                cancellationSource.Cancel();
+
+                Assert.ThrowsException<OperationCanceledException>(() =>
+                {
+                    IRazorEngineCompiledTemplate template = razorEngine.Compile("Hello @Model.Name", null, cancellationSource.Token);
+                });
+            }
+        }
+
+        [TestMethod]
+        public async Task TestCompileCancellation_DynamicModelAsync()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+            using (CancellationTokenSource cancellationSource = new CancellationTokenSource())
+            {
+                cancellationSource.Cancel();
+
+                await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+                {
+                    IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("Hello @Model.Name", null, cancellationSource.Token);
+                });
+            }
+        }
+
+        [TestMethod]
+        public void TestCompileCancellation_TypedModel1()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+            using (CancellationTokenSource cancellationSource = new CancellationTokenSource())
+            {
+                cancellationSource.Cancel();
+
+                Assert.ThrowsException<OperationCanceledException>(() =>
+                {
+                    IRazorEngineCompiledTemplate<TestTemplate1> template = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", null, cancellationSource.Token);
+                });
+            }
+        }
+
+        [TestMethod]
+        public async Task TestCompileCancellation_TypedModel1Async()
+        {
+            RazorEngine razorEngine = new RazorEngine();
+            using (CancellationTokenSource cancellationSource = new CancellationTokenSource())
+            {
+                cancellationSource.Cancel();
+
+                await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+                {
+                    IRazorEngineCompiledTemplate<TestTemplate1> template = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", null, cancellationSource.Token);
+                });
+            }
         }
 
         private static List<MetadataReference> GetMetadataReferences()

--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -739,7 +739,7 @@ namespace TestAssembly
 
                 Assert.ThrowsException<OperationCanceledException>(() =>
                 {
-                    IRazorEngineCompiledTemplate template = razorEngine.Compile("Hello @Model.Name", null, cancellationSource.Token);
+                    IRazorEngineCompiledTemplate template = razorEngine.Compile("Hello @Model.Name", cancellationToken: cancellationSource.Token);
                 });
             }
         }
@@ -754,7 +754,7 @@ namespace TestAssembly
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
                 {
-                    IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("Hello @Model.Name", null, cancellationSource.Token);
+                    IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("Hello @Model.Name", cancellationToken: cancellationSource.Token);
                 });
             }
         }
@@ -769,7 +769,7 @@ namespace TestAssembly
 
                 Assert.ThrowsException<OperationCanceledException>(() =>
                 {
-                    IRazorEngineCompiledTemplate<TestTemplate1> template = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", null, cancellationSource.Token);
+                    IRazorEngineCompiledTemplate<TestTemplate1> template = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", cancellationToken: cancellationSource.Token);
                 });
             }
         }
@@ -784,7 +784,7 @@ namespace TestAssembly
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
                 {
-                    IRazorEngineCompiledTemplate<TestTemplate1> template = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", null, cancellationSource.Token);
+                    IRazorEngineCompiledTemplate<TestTemplate1> template = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", cancellationToken: cancellationSource.Token);
                 });
             }
         }

--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -6,24 +6,14 @@ namespace RazorEngineCore
 {
     public interface IRazorEngine
     {
-        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
+        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default)
             where T : IRazorEngineTemplate;
 
-        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken)
+        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default)
             where T : IRazorEngineTemplate;
 
-        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
-            where T : IRazorEngineTemplate;
+        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default);
 
-        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken)
-            where T : IRazorEngineTemplate;
-
-        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
-
-        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken);
-
-        Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
-
-        Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken);
+        Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default);
     }
 }

--- a/RazorEngineCore/IRazorEngine.cs
+++ b/RazorEngineCore/IRazorEngine.cs
@@ -1,18 +1,29 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RazorEngineCore
 {
     public interface IRazorEngine
     {
-        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
+        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
             where T : IRazorEngineTemplate;
-        
-        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) 
+
+        IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken)
             where T : IRazorEngineTemplate;
-        
+
+        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
+            where T : IRazorEngineTemplate;
+
+        Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken)
+            where T : IRazorEngineTemplate;
+
         IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
-        
+
+        IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken);
+
         Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null);
+
+        Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken);
     }
 }

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -15,12 +15,7 @@ namespace RazorEngineCore
 {
     public class RazorEngine : IRazorEngine
     {
-        public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate
-        {
-            return Compile<T>(content, builderAction, cancellationToken: default);
-        }
-
-        public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken) where T : IRazorEngineTemplate
+        public IRazorEngineCompiledTemplate<T> Compile<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default) where T : IRazorEngineTemplate
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
 
@@ -34,22 +29,12 @@ namespace RazorEngineCore
             return new RazorEngineCompiledTemplate<T>(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
-        public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null) where T : IRazorEngineTemplate
-        {
-            return CompileAsync<T>(content, builderAction, cancellationToken: default);
-        }
-
-        public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken) where T : IRazorEngineTemplate
+        public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default) where T : IRazorEngineTemplate
         {
             return Task.Factory.StartNew(() => this.Compile<T>(content: content, builderAction: builderAction, cancellationToken: cancellationToken));
         }
 
-        public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
-        {
-            return Compile(content, builderAction, cancellationToken: default);
-        }
-
-        public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken)
+        public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default)
         {
             IRazorEngineCompilationOptionsBuilder compilationOptionsBuilder = new RazorEngineCompilationOptionsBuilder();
             compilationOptionsBuilder.Inherits(typeof(RazorEngineTemplateBase));
@@ -61,19 +46,9 @@ namespace RazorEngineCore
             return new RazorEngineCompiledTemplate(memoryStream, compilationOptionsBuilder.Options.TemplateNamespace);
         }
 
-        public Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null)
-        {
-            return CompileAsync(content, builderAction, cancellationToken: default);
-        }
-
-        public Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction, CancellationToken cancellationToken)
+        public Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default)
         {
             return Task.Factory.StartNew(() => this.Compile(content: content, builderAction: builderAction, cancellationToken: cancellationToken));
-        }
-
-        protected virtual MemoryStream CreateAndCompileToStream(string templateSource, RazorEngineCompilationOptions options)
-        {
-            return CreateAndCompileToStream(templateSource, options, cancellationToken: default);
         }
 
         protected virtual MemoryStream CreateAndCompileToStream(string templateSource, RazorEngineCompilationOptions options, CancellationToken cancellationToken)


### PR DESCRIPTION
Since `CSharpCompilation.Emit` and `CSharpSyntaxTree.Parse` support cancellation, it'd be good to be able to forward cancellation tokens down to those potentially long-running methods. Ideally they'd have been optional parameters added to each of the compile methods, however that would be a breaking change to the API so I've added them as overloads.