### PR TITLE
Fill the incomplete usage of async methods.

### DIFF
--- a/ExampleAppCore/ExampleAppCore.csproj
+++ b/ExampleAppCore/ExampleAppCore.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExampleAppNet472/ExampleAppNET472.csproj
+++ b/ExampleAppNet472/ExampleAppNET472.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RazorEngineCore.Tests/RazorEngineCore.Tests.csproj
+++ b/RazorEngineCore.Tests/RazorEngineCore.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -739,7 +739,7 @@ namespace TestAssembly
 
                 Assert.ThrowsException<OperationCanceledException>(() =>
                 {
-                    IRazorEngineCompiledTemplate template = razorEngine.Compile("Hello @Model.Name", cancellationToken: cancellationSource.Token);
+                    _ = razorEngine.Compile("Hello @Model.Name", cancellationToken: cancellationSource.Token);
                 });
             }
         }
@@ -754,7 +754,7 @@ namespace TestAssembly
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
                 {
-                    IRazorEngineCompiledTemplate template = await razorEngine.CompileAsync("Hello @Model.Name", cancellationToken: cancellationSource.Token);
+                    _ = await razorEngine.CompileAsync("Hello @Model.Name", cancellationToken: cancellationSource.Token);
                 });
             }
         }
@@ -769,7 +769,7 @@ namespace TestAssembly
 
                 Assert.ThrowsException<OperationCanceledException>(() =>
                 {
-                    IRazorEngineCompiledTemplate<TestTemplate1> template = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", cancellationToken: cancellationSource.Token);
+                    _ = razorEngine.Compile<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", cancellationToken: cancellationSource.Token);
                 });
             }
         }
@@ -784,7 +784,7 @@ namespace TestAssembly
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
                 {
-                    IRazorEngineCompiledTemplate<TestTemplate1> template = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", cancellationToken: cancellationSource.Token);
+                    _ = await razorEngine.CompileAsync<TestTemplate1>("Hello @A @B @(A + B) @C @Decorator(\"777\")", cancellationToken: cancellationSource.Token);
                 });
             }
         }

--- a/RazorEngineCore/AnonymousTypeWrapper.cs
+++ b/RazorEngineCore/AnonymousTypeWrapper.cs
@@ -32,7 +32,7 @@ namespace RazorEngineCore
                 return true;
             }
 
-            var type = result.GetType();
+            //var type = result.GetType();
 
             if (result.IsAnonymous())
             {
@@ -41,12 +41,7 @@ namespace RazorEngineCore
 
             if (result is IDictionary dictionary)
             {
-                List<object> keys = new List<object>();
-
-                foreach(object key in dictionary.Keys)
-                {
-                    keys.Add(key);
-                }
+                List<object> keys = dictionary.Keys.Cast<object>().ToList();
 
                 foreach(object key in keys)
                 {
@@ -56,22 +51,13 @@ namespace RazorEngineCore
                     }
                 }
             }
-            else if (result is IEnumerable enumerable && !(result is string))
+            else if (result is IEnumerable enumerable and not string)
             {
                 result = enumerable.Cast<object>()
-                        .Select(e =>
-                        {
-                            if (e.IsAnonymous())
-                            {
-                                return new AnonymousTypeWrapper(e);
-                            }
-
-                            return e;
-                        })
+                        .Select(e => e.IsAnonymous() ? new AnonymousTypeWrapper(e) : e)
                         .ToList();
             }
-
-
+            
             return true;
         }
     }

--- a/RazorEngineCore/ObjectExtenders.cs
+++ b/RazorEngineCore/ObjectExtenders.cs
@@ -4,6 +4,7 @@ using System.Dynamic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace RazorEngineCore
 {
@@ -32,18 +33,25 @@ namespace RazorEngineCore
                    && type.Attributes.HasFlag(TypeAttributes.NotPublic);
         }
 
-        public static long ReadLong(this Stream stream)
+        public static async Task<long> ReadLong(this Stream stream)
         {
             byte[] buffer = new byte[8];
-            stream.Read(buffer, 0, 8);
-
+#if NETSTANDARD2_0
+            _ = await stream.ReadAsync(buffer, 0, buffer.Length);
+#else
+            _ = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
+#endif
             return BitConverter.ToInt64(buffer, 0);
         }
 
-        public static void WriteLong(this Stream stream, long value)
+        public static async Task WriteLong(this Stream stream, long value)
         {
             byte[] buffer = BitConverter.GetBytes(value);
-            stream.Write(buffer, 0, buffer.Length);
+#if NETSTANDARD2_0
+            await stream.WriteAsync(buffer, 0, buffer.Length);
+#else
+            await stream.WriteAsync(buffer);
+#endif
         }
     }
 }

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -30,7 +30,7 @@ namespace RazorEngineCore
 
         public Task<IRazorEngineCompiledTemplate<T>> CompileAsync<T>(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default) where T : IRazorEngineTemplate
         {
-            return Task.Factory.StartNew(() => this.Compile<T>(content: content, builderAction: builderAction, cancellationToken: cancellationToken));
+            return Task.Run(() => this.Compile<T>(content: content, builderAction: builderAction, cancellationToken: cancellationToken));
         }
 
         public IRazorEngineCompiledTemplate Compile(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default)
@@ -46,7 +46,7 @@ namespace RazorEngineCore
 
         public Task<IRazorEngineCompiledTemplate> CompileAsync(string content, Action<IRazorEngineCompilationOptionsBuilder> builderAction = null, CancellationToken cancellationToken = default)
         {
-            return Task.Factory.StartNew(() => this.Compile(
+            return Task.Run(() => this.Compile(
                 content, 
                 builderAction, 
                 cancellationToken));
@@ -105,7 +105,9 @@ namespace RazorEngineCore
                    })
                     .Concat(options.MetadataReferences)
                     .ToList(),
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                    .WithOptimizationLevel(OptimizationLevel.Release)
+                    .WithOverflowChecks(true));
 
 
             MemoryStream assemblyStream = new MemoryStream();

--- a/RazorEngineCore/RazorEngineCompilationOptionsBuilder.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptionsBuilder.cs
@@ -63,9 +63,10 @@ namespace RazorEngineCore
 
             string result = string.Join(".", elements.Where(e => !string.IsNullOrWhiteSpace(e)));
 
-            if (result.Contains('`'))
+            int tildeLocation = result.IndexOf('`');
+            if (tildeLocation > -1)
             {
-                result = result.Substring(0, result.IndexOf("`"));
+                result = result.Substring(0, tildeLocation);
             }
 
             if (type.GenericTypeArguments.Length == 0)

--- a/RazorEngineCore/RazorEngineCompiledTemplate.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplate.cs
@@ -22,13 +22,17 @@ namespace RazorEngineCore
 
         public static async Task<RazorEngineCompiledTemplate> LoadFromFileAsync(string fileName)
         {
+#if NETSTANDARD2_0
             using (FileStream fileStream = new FileStream(
-                path: fileName, 
-                mode: FileMode.Open, 
-                access: FileAccess.Read,
-                share: FileShare.None,
-                bufferSize: 4096, 
-                useAsync: true))
+#else
+            await using (FileStream fileStream = new FileStream(
+#endif
+                       path: fileName, 
+                       mode: FileMode.Open, 
+                       access: FileAccess.Read,
+                       share: FileShare.None,
+                       bufferSize: 4096, 
+                       useAsync: true))
             {
                 return await LoadFromStreamAsync(fileStream);
             }

--- a/RazorEngineCore/RazorEngineCompiledTemplateBase.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplateBase.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace RazorEngineCore
@@ -19,7 +18,11 @@ namespace RazorEngineCore
 
         public async Task SaveToFileAsync(string fileName)
         {
+#if NETSTANDARD2_0
             using (FileStream fileStream = new FileStream(
+#else
+            await using (FileStream fileStream = new FileStream(
+#endif
                        path: fileName,
                        mode: FileMode.OpenOrCreate,
                        access: FileAccess.Write,
@@ -36,9 +39,9 @@ namespace RazorEngineCore
             this.SaveToStreamAsync(stream).GetAwaiter().GetResult();
         }
 
-        public async Task SaveToStreamAsync(Stream stream)
+        public Task SaveToStreamAsync(Stream stream)
         {
-            await this.Meta.Write(stream);
+            return this.Meta.Write(stream);
         }
 
         public void EnableDebugging(string debuggingOutputDirectory = null)

--- a/RazorEngineCore/RazorEngineCompiledTemplateT.cs
+++ b/RazorEngineCore/RazorEngineCompiledTemplateT.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace RazorEngineCore
 {
@@ -24,13 +23,17 @@ namespace RazorEngineCore
         
         public static async Task<RazorEngineCompiledTemplate<T>> LoadFromFileAsync(string fileName)
         {
+#if NETSTANDARD2_0
             using (FileStream fileStream = new FileStream(
-                       path: fileName,
-                       mode: FileMode.Open,
-                       access: FileAccess.Read,
-                       share: FileShare.None,
-                       bufferSize: 4096,
-                       useAsync: true))
+#else
+            await using (FileStream fileStream = new FileStream(
+#endif
+                             path: fileName,
+                             mode: FileMode.Open,
+                             access: FileAccess.Read,
+                             share: FileShare.None,
+                             bufferSize: 4096,
+                             useAsync: true))
             {
                 return await LoadFromStreamAsync(fileStream);
             }
@@ -53,7 +56,7 @@ namespace RazorEngineCore
         
         public async Task<string> RunAsync(Action<T> initializer)
         {
-            T instance = (T) Activator.CreateInstance(this.TemplateType);
+            var instance = (T) Activator.CreateInstance(this.TemplateType);
             initializer(instance);
 
             if (this.IsDebuggerEnabled && instance is RazorEngineTemplateBase instance2)

--- a/RazorEngineCore/RazorEngineCore.csproj
+++ b/RazorEngineCore/RazorEngineCore.csproj
@@ -12,6 +12,7 @@
 		<Company>Alexander Selishchev</Company>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>latest</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/RazorEngineCore/RazorEngineCore.csproj
+++ b/RazorEngineCore/RazorEngineCore.csproj
@@ -21,9 +21,9 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.1" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	<PropertyGroup>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
I apologize if I don't know the historical reasons why not all the methods are async. I did a quick review and wanted to share my notes. I hope some of these changes useful.

All tests pass without modification.

 - Prefer Task.Run over Task.Factory.StartNew
 - Compile in release mode with overflow checks for safety.
 - Implement `await using` when available.
 - Remove unused `result.GetType();`
 - CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync