### PR TITLE
Make ProjectEngineBuilderAction  public and invoke it when compiling template.

### DIFF
--- a/RazorEngineCore.Tests/TestCompileAndRun.cs
+++ b/RazorEngineCore.Tests/TestCompileAndRun.cs
@@ -909,6 +909,27 @@ Hello @Model.Decorator(Model.C)
         }
 
         [TestMethod]
+        public void TestCompileAndRun_ProjectEngineBuilderAction_IsInvoked()
+        {
+            var builderActionIsInvoked = false; 
+            RazorEngine razorEngine = new RazorEngine();
+            IRazorEngineCompiledTemplate template = razorEngine.Compile("<h1>Hello @Model.Name</h1>", builder =>
+            {
+                builder.IncludeDebuggingInfo();
+                builder.Options.ProjectEngineBuilderAction = (x) => builderActionIsInvoked = true;
+            });
+
+            template.EnableDebugging();
+
+            string actual = template.Run(new
+            {
+                Name = "Alex"
+            });
+
+            Assert.IsTrue(builderActionIsInvoked);
+        }
+
+        [TestMethod]
         public void TestCompileAndRun_Typed_EnabledDebuggingThrowsException()
         {
             string templateText = @"

--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -67,6 +67,7 @@ namespace RazorEngineCore
                 (builder) =>
                 {
                     builder.SetNamespace(options.TemplateNamespace);
+                    options.ProjectEngineBuilderAction?.Invoke(builder);
                 });
 
             RazorSourceDocument document = RazorSourceDocument.Create(templateSource, fileName);

--- a/RazorEngineCore/RazorEngineCompilationOptions.cs
+++ b/RazorEngineCore/RazorEngineCompilationOptions.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using System;
+using Microsoft.AspNetCore.Razor.Language;
 
 namespace RazorEngineCore
 {
@@ -22,6 +23,7 @@ namespace RazorEngineCore
             "System.Collections",
             "System.Collections.Generic"
         };
+        public Action<RazorProjectEngineBuilder> ProjectEngineBuilderAction { get; set; }
 
         public RazorEngineCompilationOptions()
         {


### PR DESCRIPTION
Add support for custom extensions like @section directive processing by making ProjectEngineBuilderAction public and invoking it upon compilation.