### PR TITLE
Fix .NET8 for AOT / Single Executable

### DIFF
--- a/ExampleAppNET8/ExampleAppNET8.csproj
+++ b/ExampleAppNET8/ExampleAppNET8.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RazorEngineCore\RazorEngineCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="template1.cshtml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="template2.cshtml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/ExampleAppNET8/Program.cs
+++ b/ExampleAppNET8/Program.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using RazorEngineCore;
+
+namespace ExampleAppNET5
+{
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            IRazorEngine razorEngine = new RazorEngine();
+            IRazorEngineCompiledTemplate template1 = razorEngine.Compile("Hello <h1>@Model.Name</h1>");
+
+            string result = template1.Run(new
+            {
+	            Name = "<b>Alex</b>"
+			});
+
+            Console.WriteLine(result);
+        }
+
+
+        static void ReadFromFileAndRun()
+        {
+            IRazorEngine razorEngine = new RazorEngine();
+            string templateText = File.ReadAllText("template2.cshtml");
+
+            IRazorEngineCompiledTemplate template2 = razorEngine.Compile(templateText, builder =>
+            {
+                builder.IncludeDebuggingInfo();
+            });
+
+            if (!Directory.Exists("Temp"))
+            {
+                Directory.CreateDirectory("Temp");
+            }
+
+            template2.EnableDebugging("Temp");
+
+            string result = template2.Run(new
+            {
+                Name = "Alexander",
+                Items = new List<string>()
+                {
+                    "item 1",
+                    "item 2"
+                }
+            });
+
+            Console.WriteLine(result);
+            Console.ReadKey();
+        }
+    }
+}

--- a/ExampleAppNET8/template1.cshtml
+++ b/ExampleAppNET8/template1.cshtml
@@ -1,0 +1,24 @@
+﻿Hello @Model.Name
+
+@foreach(var item in @Model.Items)
+{
+    <div>- @item</div>
+}
+
+<div data-name=""@Model.Name""></div>
+
+<area>
+    @{ RecursionTest(3); }
+</area>
+
+@{
+	void RecursionTest(int level){
+		if (level <= 0)
+		{
+			return;
+		}
+			
+		<div>LEVEL: @level</div>
+		@{ RecursionTest(level - 1); }
+	}
+}

--- a/ExampleAppNET8/template2.cshtml
+++ b/ExampleAppNET8/template2.cshtml
@@ -1,0 +1,24 @@
+﻿<div>
+    <h1>Hello</h1>
+
+    @{ Breakpoint(); }
+
+    @if (Model != null)
+    {
+        <h2>Hello @Model</h2>
+    }
+
+    <h3>111</h3>
+
+    @if (Model != null)
+    {
+        <h2>Hello @Model</h2>
+    }
+
+    <h3>111</h3>
+
+    @if (Model != null)
+    {
+        <h2>Hello @Model</h2>
+    }
+</div>

--- a/RazorEngineCore.Tests/RazorEngineCore.Tests.csproj
+++ b/RazorEngineCore.Tests/RazorEngineCore.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RazorEngineCore.sln
+++ b/RazorEngineCore.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleAppNET472", "Example
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleAppNET5", "ExampleAppNET5\ExampleAppNET5.csproj", "{B19C090A-4EC1-441D-B702-ADD2ECA79198}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleAppNET8", "ExampleAppNET8\ExampleAppNET8.csproj", "{9E5835E0-F768-4ADE-9A1F-61FE6B411B8F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{B19C090A-4EC1-441D-B702-ADD2ECA79198}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B19C090A-4EC1-441D-B702-ADD2ECA79198}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B19C090A-4EC1-441D-B702-ADD2ECA79198}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E5835E0-F768-4ADE-9A1F-61FE6B411B8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E5835E0-F768-4ADE-9A1F-61FE6B411B8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E5835E0-F768-4ADE-9A1F-61FE6B411B8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E5835E0-F768-4ADE-9A1F-61FE6B411B8F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RazorEngineCore/RazorEngineCore.csproj
+++ b/RazorEngineCore/RazorEngineCore.csproj
@@ -21,8 +21,8 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.31" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	<PropertyGroup>


### PR DESCRIPTION
This PR updates the references to `Microsoft.AspNetCore.Razor.Language` and `Microsoft.CodeAnalysis.CSharp` to their latest versions in order to fix the Ahead-of-Time (AOT) compilation of the assembly in .NET 8.

AOT allows publishing of your entire application as a single executable, with all assemblies pre-compiled natively, resulting in faster startup time.
The older versions of those libraries are not compatible with AOT and cause errors when publishing for AOT.

The upgrade does not appear to cause any issues, and all tests still pass.
I've added ExampleAppNET8 project, and AOT functionality can be tested by right-clicking it and selecting Publish.