### PR TITLE
adjust optimize level when options.IncludeDebuggingInfo is true.

### DIFF
--- a/RazorEngineCore/RazorEngine.cs
+++ b/RazorEngineCore/RazorEngine.cs
@@ -107,7 +107,7 @@ namespace RazorEngineCore
                     .Concat(options.MetadataReferences)
                     .ToList(),
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                    .WithOptimizationLevel(OptimizationLevel.Release)
+                    .WithOptimizationLevel(options.IncludeDebuggingInfo ? OptimizationLevel.Debug : OptimizationLevel.Release)
                     .WithOverflowChecks(true));
 
 


### PR DESCRIPTION
Debug example doesn't working well on my machine then I figured out there is not enough information for debuging.

## Before
                    .WithOptimizationLevel(OptimizationLevel.Release)

![K-003](https://github.com/user-attachments/assets/130db4aa-b8f3-4ea2-88f0-b8412990db1f)

## After
                    .WithOptimizationLevel(options.IncludeDebuggingInfo ? OptimizationLevel.Debug : OptimizationLevel.Release)

![K-004](https://github.com/user-attachments/assets/0605b09f-44b5-4318-a918-98e356cbed7e)
